### PR TITLE
Finish fixing #14 and also do not unserialize fees

### DIFF
--- a/Boolfly/PaymentFee/Helper/Data.php
+++ b/Boolfly/PaymentFee/Helper/Data.php
@@ -37,7 +37,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     protected function _getMethodFee() {
 
         if (is_null($this->methodFee)) {
-            $fees = unserialize($this->getConfig('fee'));
+            $fees = $this->getConfig('fee'); //unserialize($this->getConfig('fee'));
             if(is_array($fees)) {
                 foreach ($fees as $fee) {
                     $this->methodFee[$fee['payment_method']] = array(

--- a/Boolfly/PaymentFee/Setup/UpgradeSchema.php
+++ b/Boolfly/PaymentFee/Setup/UpgradeSchema.php
@@ -33,8 +33,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'fee_amount',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Fee Amount'
                 ]
@@ -45,8 +45,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'base_fee_amount',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Base Fee Amount'
                 ]
@@ -58,8 +58,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'fee_amount',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Fee Amount'
 
@@ -72,8 +72,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'base_fee_amount',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Base Fee Amount'
 
@@ -86,8 +86,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'fee_amount_refunded',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Base Fee Amount Refunded'
                 ]
@@ -98,8 +98,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'base_fee_amount_refunded',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Base Fee Amount Refunded'
                 ]
@@ -110,8 +110,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'fee_amount_invoiced',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Fee Amount Invoiced'
                 ]
@@ -122,8 +122,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'base_fee_amount_invoiced',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Base Fee Amount Invoiced'
                 ]
@@ -135,8 +135,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'fee_amount',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Fee Amount'
 
@@ -148,8 +148,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'base_fee_amount',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Base Fee Amount'
 
@@ -162,8 +162,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'fee_amount',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Fee Amount'
 
@@ -175,8 +175,8 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 'base_fee_amount',
                 [
                     'type' => \Magento\Framework\DB\Ddl\Table::TYPE_DECIMAL,
-                    '10,2',
-                    'default' => 0.00,
+                    'length' => '12,4',
+                    'default' => 0.0000,
                     'nullable' => true,
                     'comment' =>'Base Fee Amount'
 


### PR DESCRIPTION
When trying to register a new user after installing this module, I would receive an error "error at offset 0 of x bytes" on the `unserialize` call of `_getMethodFee`. It seems the value was already deserialized, so using it straight out of config works. This is using Magento 2.2, so perhaps this is a new change? Would appreciate some feedback on the serialization and/or testing on older Magento versions.