### PR TITLE
Fix Double Fee, Paypal Checkout, Rounding Fee

### DIFF
--- a/Block/Sales/Totals.php
+++ b/Block/Sales/Totals.php
@@ -52,22 +52,25 @@ class Totals extends \Magento\Framework\View\Element\Template
      */
     public function initTotals()
     {
+        
         $parent = $this->getParentBlock();
         $this->_order = $parent->getOrder();
         $this->_source = $parent->getSource();
         if(!$this->_source->getFeeAmount()) {
             return $this;
         }
+
         $fee = new \Magento\Framework\DataObject(
             [
                 'code' => 'fee',
                 'strong' => false,
                 'value' => $this->_source->getFeeAmount(),
-                'label' => __('Surcharge Fee'),
+                'label' => __('Payment Fee'),
             ]
         );
 
         $parent->addTotal($fee, 'fee');
+
         return $this;
     }
 }

--- a/Controller/Checkout/Totals.php
+++ b/Controller/Checkout/Totals.php
@@ -21,6 +21,10 @@ class Totals extends \Magento\Framework\App\Action\Action
      * @var \Magento\Framework\Json\Helper\Data
      */
     protected $_helper;
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
 
     /**
      * @var \Magento\Quote\Api\CartRepositoryInterface
@@ -32,7 +36,8 @@ class Totals extends \Magento\Framework\App\Action\Action
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Framework\Json\Helper\Data $helper,
         \Magento\Framework\Controller\Result\JsonFactory $resultJson,
-        \Magento\Quote\Api\CartRepositoryInterface $quoteRepository
+        \Magento\Quote\Api\CartRepositoryInterface $quoteRepository,
+        \Psr\Log\LoggerInterface $loggerInterface
     )
     {
         parent::__construct($context);
@@ -40,6 +45,7 @@ class Totals extends \Magento\Framework\App\Action\Action
         $this->_helper = $helper;
         $this->_resultJson = $resultJson;
         $this->quoteRepository = $quoteRepository;
+        $this->logger = $loggerInterface;
     }
 
     /**
@@ -56,6 +62,7 @@ class Totals extends \Magento\Framework\App\Action\Action
         try {
             $this->quoteRepository->get($this->_checkoutSession->getQuoteId());
             $quote = $this->_checkoutSession->getQuote();
+
             //Trigger to re-calculate totals
             $payment = $this->_helper->jsonDecode($this->getRequest()->getContent());
             $this->_checkoutSession->getQuote()->getPayment()->setMethod($payment['payment']);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -130,7 +130,6 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         if ($feeType != \Magento\Shipping\Model\Carrier\AbstractCarrier::HANDLING_TYPE_FIXED) {
             $subTotal = $quote->getSubtotal();
             $fee = $subTotal * ($fee / 100);
-            $fee = 100;
         }
 
         // $fee = $this->pricingHelper->currency($fee, false, false);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -2,8 +2,6 @@
 
 namespace Boolfly\PaymentFee\Helper;
 
-
-
 use Magento\Framework\Serialize\SerializerInterface;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -3,6 +3,7 @@
 namespace Boolfly\PaymentFee\Helper;
 
 use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
 
 class Data extends \Magento\Framework\App\Helper\AbstractHelper
 {
@@ -28,6 +29,14 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     protected $serializer;
     /**
+     * @var Data
+     */
+    protected $pricingHelper;
+    /**
+     * @var PriceCurrency
+     */
+    protected $priceCurrency;
+    /**
      * @var LoggerInterface
      */
     protected $logger;
@@ -35,12 +44,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
         SerializerInterface $serializer,
+        \Magento\Framework\Pricing\Helper\Data $pricingHelper,
+        \Magento\Directory\Model\PriceCurrency $priceCurrency,
         \Psr\Log\LoggerInterface $loggerInterface
     )
     {
         parent::__construct($context);
         $this->serializer = $serializer;
         $this->_getMethodFee();
+        $this->pricingHelper = $pricingHelper;
+        $this->priceCurrency = $priceCurrency;
         $this->logger = $loggerInterface;
     }
 
@@ -109,16 +122,21 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @return float|int
      */
     public function getFee(\Magento\Quote\Model\Quote $quote) {
+
         $method  = $quote->getPayment()->getMethod();
         $fee     = $this->methodFee[$method]['fee'];
         $feeType = $this->getFeeType();
 
-        if ($feeType == \Magento\Shipping\Model\Carrier\AbstractCarrier::HANDLING_TYPE_FIXED) {
-            return $fee;
-        } else {
+        if ($feeType != \Magento\Shipping\Model\Carrier\AbstractCarrier::HANDLING_TYPE_FIXED) {
             $subTotal = $quote->getSubtotal();
-            return ($subTotal * ($fee / 100));
+            $fee = $subTotal * ($fee / 100);
+            $fee = 100;
         }
+
+        // $fee = $this->pricingHelper->currency($fee, false, false);
+        $fee = $this->priceCurrency->round($fee);
+
+        return $fee;
     }
 
     /**

--- a/Model/Order/Total/Creditmemo/Fee.php
+++ b/Model/Order/Total/Creditmemo/Fee.php
@@ -7,6 +7,22 @@ use Magento\Sales\Model\Order\Creditmemo\Total\AbstractTotal;
 class Fee extends AbstractTotal
 {
     /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * Credit Memo Fee constructor.
+     * @param \Psr\Log\LoggerInterface $loggerInterface
+     */
+    public function __construct(
+        \Psr\Log\LoggerInterface $loggerInterface
+    )
+    {
+        $this->logger = $loggerInterface;
+    }
+
+    /**
      * @param \Magento\Sales\Model\Order\Creditmemo $creditmemo
      * @return $this
      */

--- a/Model/Order/Total/Invoice/Fee.php
+++ b/Model/Order/Total/Invoice/Fee.php
@@ -8,6 +8,22 @@ class Fee extends AbstractTotal
 {
 
     /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * Invoice Fee constructor.
+     * @param \Psr\Log\LoggerInterface $loggerInterface
+     */
+    public function __construct(
+        \Psr\Log\LoggerInterface $loggerInterface
+    )
+    {
+        $this->logger = $loggerInterface;
+    }
+
+    /**
      * Collect invoice subtotal
      *
      * @param \Magento\Sales\Model\Order\Invoice $invoice
@@ -19,6 +35,7 @@ class Fee extends AbstractTotal
         $order = $invoice->getOrder();
         $feeAmount = $order->getFeeAmount();
         $baseFeeAmount = $order->getBaseFeeAmount();
+
         $invoice->setFeeAmount($feeAmount);
         $invoice->setBaseFeeAmount($baseFeeAmount);
         $invoice->setGrandTotal($invoice->getGrandTotal() + $feeAmount);

--- a/Model/Quote/Address/Total/Fee.php
+++ b/Model/Quote/Address/Total/Fee.php
@@ -81,11 +81,15 @@ class Fee extends AbstractTotal
         
         $total->setFeeAmount($fee);
         $total->setBaseFeeAmount($fee);
+        
+        $total->setTotalAmount('fee_amount', $fee);
+        $total->setBaseTotalAmount('base_fee_amount', $fee);
+        
         // // Duplicate fee added when this is added
-        // $total->setTotalAmount('fee_amount', $fee);
-        // $total->setBaseTotalAmount('base_fee_amount', $fee);
-        $total->setGrandTotal($total->getGrandTotal() + $total->getFeeAmount());
-        $total->setBaseGrandTotal($total->getBaseGrandTotal() + $total->getBaseFeeAmount());
+        // $total->setGrandTotal($total->getGrandTotal() + $total->getFeeAmount());
+        // $total->setBaseGrandTotal($total->getBaseGrandTotal() + $total->getBaseFeeAmount());
+        $total->setGrandTotal($total->getGrandTotal());
+        $total->setBaseGrandTotal($total->getBaseGrandTotal());
 
         // Make sure that quote is also updated
         $quote->setFeeAmount($fee);

--- a/Model/Quote/Address/Total/Fee.php
+++ b/Model/Quote/Address/Total/Fee.php
@@ -2,7 +2,9 @@
 
 namespace Boolfly\PaymentFee\Model\Quote\Address\Total;
 
-class Fee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
+use Magento\Quote\Model\Quote\Address\Total\AbstractTotal;
+
+class Fee extends AbstractTotal
 {
     /**
      * @var string
@@ -16,6 +18,10 @@ class Fee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
      * @var \Magento\Checkout\Model\Session
      */
     protected $_checkoutSession;
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
 
     /**
      * Collect grand total address amount
@@ -33,17 +39,20 @@ class Fee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
      * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param \Magento\Quote\Api\Data\PaymentInterface $payment
      * @param \Boolfly\PaymentFee\Helper\Data $helperData
+     * @param \Psr\Log\LoggerInterface $loggerInterface
      */
     public function __construct(
         \Magento\Quote\Model\QuoteValidator $quoteValidator,
         \Magento\Checkout\Model\Session $checkoutSession,
         \Magento\Quote\Api\Data\PaymentInterface $payment,
-        \Boolfly\PaymentFee\Helper\Data $helperData
+        \Boolfly\PaymentFee\Helper\Data $helperData,
+        \Psr\Log\LoggerInterface $loggerInterface
     )
     {
         $this->_quoteValidator = $quoteValidator;
         $this->_helperData = $helperData;
         $this->_checkoutSession = $checkoutSession;
+        $this->logger = $loggerInterface;
     }
 
     /**
@@ -69,10 +78,12 @@ class Fee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
         if($this->_helperData->canApply($quote)) {
             $fee = $this->_helperData->getFee($quote);
         }
+        
         $total->setFeeAmount($fee);
         $total->setBaseFeeAmount($fee);
-        $total->setTotalAmount('fee_amount', $fee);
-        $total->setBaseTotalAmount('base_fee_amount', $fee);
+        // // Duplicate fee added when this is added
+        // $total->setTotalAmount('fee_amount', $fee);
+        // $total->setBaseTotalAmount('base_fee_amount', $fee);
         $total->setGrandTotal($total->getGrandTotal() + $total->getFeeAmount());
         $total->setBaseGrandTotal($total->getBaseGrandTotal() + $total->getBaseFeeAmount());
 
@@ -98,7 +109,7 @@ class Fee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
     {
         $result = [
             'code' => $this->getCode(),
-            'title' => __('Surcharge Fee'),
+            'title' => __('Payment Fee'),
             'value' => $total->getFeeAmount()
         ];
         return $result;
@@ -111,6 +122,6 @@ class Fee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
      */
     public function getLabel()
     {
-        return __('Surcharge Fee');
+        return __('Payment Fee');
     }
 }

--- a/Observer/AddFeeToOrderObserver.php
+++ b/Observer/AddFeeToOrderObserver.php
@@ -15,6 +15,10 @@ class AddFeeToOrderObserver implements ObserverInterface
 
     /** @var Data  */
     protected $_helper;
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
 
     /**
      * AddFeeToOrderObserver constructor.
@@ -22,11 +26,13 @@ class AddFeeToOrderObserver implements ObserverInterface
      */
     public function __construct(
         \Magento\Checkout\Model\Session $checkoutSession,
-        Data $helper
+        Data $helper,
+        \Psr\Log\LoggerInterface $loggerInterface
     )
     {
         $this->_checkoutSession = $checkoutSession;
         $this->_helper = $helper;
+        $this->logger = $loggerInterface;
     }
 
     /**

--- a/Plugin/LogPayPalNVPRequest.php
+++ b/Plugin/LogPayPalNVPRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Boolfly\PaymentFee\Plugin;
+
+class LogPayPalNVPRequest
+{
+
+    protected $logger;
+
+    public function __construct(
+        \Psr\Log\LoggerInterface $logger
+    ) {
+        $this->logger = $logger;
+    }
+
+    public function beforeCall(\Magento\Paypal\Model\Api\Nvp $nvp, $methodName, array $request) {
+
+        $this->logger->debug(__METHOD__ . " methodName $methodName ");
+        $this->logger->debug(__METHOD__ . " request " . print_r($request,true));
+    }
+}

--- a/Plugin/UpdateFeeForOrder.php
+++ b/Plugin/UpdateFeeForOrder.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Boolfly\PaymentFee\Plugin;
+
+class UpdateFeeForOrder
+{
+    /**
+     * @var \Magento\Quote\Model\QuoteFactory
+     */
+    protected $quote;
+    protected $logger;
+    protected $_checkoutSession;
+    protected $_registry;
+
+    public function __construct(
+        \Magento\Quote\Model\Quote $quote,
+        \Psr\Log\LoggerInterface $logger,
+        \Magento\Checkout\Model\Session $checkoutSession,
+        \Magento\Framework\Registry $registry
+    ) {
+        $this->quote = $quote;
+        $this->logger = $logger;
+        $this->_checkoutSession = $checkoutSession;
+        $this->_registry = $registry;
+    }
+
+    /**
+     * Get shipping, tax, subtotal and discount amounts all together
+     *
+     * @return array
+     */
+    public function beforeGetAllItems($cart)
+    {
+        // $paypalTest = $this->_registry->registry('is_paypal_items')? $this->_registry->registry('is_paypal_items') : 0;
+        // $quote = $this->_checkoutSession->getQuote();
+        // $paymentMethod = $quote->getPayment()->getMethod();
+        
+        // $paypalMehodList = ['payflowpro','payflow_link','payflow_advanced','braintree_paypal','paypal_express_bml','payflow_express_bml','payflow_express','paypal_express'];
+        // if($paypalTest < 3 && in_array($paymentMethod,$paypalMehodList)){
+        //     if(method_exists($cart , 'addCustomItem' )) {
+        //         $cart->addCustomItem(__("Payment Fee"), 1 ,$quote->getFeeAmount());
+        //         $reg = $this->_registry->registry('is_paypal_items');
+        //         $current = $reg + 1 ;
+        //         $this->_registry->unregister('is_paypal_items');
+        //         $this->_registry->register('is_paypal_items', $current);
+        //     }
+        // }
+    }
+}
+ 

--- a/Plugin/UpdateFeeForOrder.php
+++ b/Plugin/UpdateFeeForOrder.php
@@ -31,20 +31,51 @@ class UpdateFeeForOrder
      */
     public function beforeGetAllItems($cart)
     {
-        // $paypalTest = $this->_registry->registry('is_paypal_items')? $this->_registry->registry('is_paypal_items') : 0;
-        // $quote = $this->_checkoutSession->getQuote();
-        // $paymentMethod = $quote->getPayment()->getMethod();
+        return;
+
+        $paypalTest = $this->_registry->registry('is_paypal_items')? $this->_registry->registry('is_paypal_items') : 0;
+        $quote = $this->_checkoutSession->getQuote();
+        $paymentMethod = $quote->getPayment()->getMethod();
+
+        $this->logger->debug(__METHOD__ . ' paymentMethod: ' .$paymentMethod);
+        $this->logger->debug(__METHOD__ . ' paypalTest: ' .$paypalTest);
         
-        // $paypalMehodList = ['payflowpro','payflow_link','payflow_advanced','braintree_paypal','paypal_express_bml','payflow_express_bml','payflow_express','paypal_express'];
-        // if($paypalTest < 3 && in_array($paymentMethod,$paypalMehodList)){
-        //     if(method_exists($cart , 'addCustomItem' )) {
-        //         $cart->addCustomItem(__("Payment Fee"), 1 ,$quote->getFeeAmount());
-        //         $reg = $this->_registry->registry('is_paypal_items');
-        //         $current = $reg + 1 ;
-        //         $this->_registry->unregister('is_paypal_items');
-        //         $this->_registry->register('is_paypal_items', $current);
-        //     }
-        // }
+        $paypalMehodList = ['payflowpro','payflow_link','payflow_advanced','braintree_paypal','paypal_express_bml','payflow_express_bml','payflow_express','paypal_express'];
+        if($paypalTest < 3 && in_array($paymentMethod,$paypalMehodList)){
+            
+            $this->logger->debug(__METHOD__ . ' correct payment theod');
+            
+            if(method_exists($cart , 'addCustomItem' )) {
+                
+                $this->logger->debug(__METHOD__ . ' addCustomItem exists');
+                
+                $feeAmount = $quote->getFeeAmount();
+                $cart->addCustomItem(__("Payment Fee"), 1 , $feeAmount);
+
+                $this->logger->debug(__METHOD__ . ' fee ' . $feeAmount);
+
+                $reg = $this->_registry->registry('is_paypal_items');
+                $current = $reg + 1 ;
+
+                $items = $quote->getAllItems();
+
+                foreach($items as $item) {
+                    $this->logger->debug(
+                        __METHOD__ . ' ID: '.$item->getProductId()."\n".
+                        'Name: '.$item->getName()."\n".
+                        'Sku: '.$item->getSku()."\n".
+                        'Quantity: '.$item->getQty()."\n".
+                        'Price: '.$item->getPrice()."\n"
+                    );            
+                }
+
+                $this->logger->debug(__METHOD__ . ' subtotal ' . $quote->getSubtotal());
+                $this->logger->debug(__METHOD__ . ' grandtotal ' . $quote->getGrandTotal());
+                
+                $this->_registry->unregister('is_paypal_items');
+                $this->_registry->register('is_paypal_items', $current);
+            }
+        }
     }
 }
  

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -8,4 +8,7 @@
     <type name="Magento\Paypal\Model\Cart">
         <plugin name="update_paypal_fee_order" type="Boolfly\PaymentFee\Plugin\UpdateFeeForOrder"/>
     </type>
+    <type name="Magento\Paypal\Model\Api\Nvp">
+        <plugin name="log_paypal_nvp_request" type="Boolfly\PaymentFee\Plugin\LogPayPalNVPRequest"/>
+    </type>
 </config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!-- 
+    Paypal will reject without this with an error code #10413 because lines items + shipping + ect. != order total
+    https://webkul.com/blog/manage-custom-amount-paypal-magento2/ 
+    http://www.ibnab.com/en/blog/magento-2/magento-2-paypal-fee-charge-and-life-cycle
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Paypal\Model\Cart">
+        <plugin name="update_paypal_fee_order" type="Boolfly\PaymentFee\Plugin\UpdateFeeForOrder"/>
+    </type>
+</config>

--- a/view/frontend/layout/checkout_cart_index.xml
+++ b/view/frontend/layout/checkout_cart_index.xml
@@ -12,7 +12,7 @@
                                         <item name="paymentfee" xsi:type="array">
                                             <item name="component"  xsi:type="string">Boolfly_PaymentFee/js/view/cart/summary/fee</item>
                                             <item name="config" xsi:type="array">
-                                                <item name="title" xsi:type="string" translate="true">Surcharge Fee</item>
+                                                <item name="title" xsi:type="string" translate="true">Payment Fee</item>
                                             </item>
                                         </item>
                                     </item>


### PR DESCRIPTION
- Fee was doubled (https://github.com/mrkhoa99/Boolfly_payment_fee/issues/24): Implemented change suggested in issue comments.
- Paypal Checkout would not work because Subtotal + Shipping + etc != Grand Total (https://github.com/mrkhoa99/Boolfly_payment_fee/issues/10#issuecomment-332534487): Added a Interceptor for Paypal Checkout to add Fee as a line item and add Fee to Subtotal (https://devdocs.magento.com/guides/v2.0/extension-dev-guide/plugins.html)
- Fee was saved as a 4 digit decimal at all times breaking Stripe checkout: Fee is now rounded using internal Magento Currency method.